### PR TITLE
[WIP] Rebuild image on ubuntu bionic 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,54 @@
-FROM ubuntu:trusty
-#FROM circleci/ruby:2.2.8
+FROM ubuntu:bionic
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y software-properties-common
+RUN apt update
+RUN apt install -y software-properties-common sudo
 
-# Install basic tools for CircleCI
-RUN sudo apt-get install -y git openssh-client openssh-server
+RUN sudo apt install -y openssh-client openssh-server
+RUN sudo apt install -y patch
+RUN sudo apt install -y git
+RUN sudo apt install -y curl
+RUN sudo apt install -y libfontconfig
+RUN sudo apt install -y libcurl4-openssl-dev
+RUN sudo apt install -y imagemagick
+RUN sudo apt install -y ffmpeg
 
-RUN sudo apt-add-repository -y ppa:rael-gc/rvm
-RUN sudo apt-get update
-RUN sudo apt-get install -y rvm
+# 8.1
+RUN sudo apt install -y nodejs
 
 # Install java
 COPY ./jdk1.8.0_144 /opt/jdk1.8.0_144
 ENV PATH="/opt/jdk1.8.0_144/bin:${PATH}"
+RUN chmod +x /opt/jdk1.8.0_144/bin/*
 
-# Install dependencies
+# mecab 0.996-5; ipadic 2.7.0-20070801+main-1
+RUN sudo apt install -y mecab mecab-ipadic-utf8 libmecab-dev
+
+# Install elasticsearch 1.7.1
 COPY ./circleci /var/tmp/circleci
 RUN chmod +x /var/tmp/circleci/*.sh
-RUN /var/tmp/circleci/install_elasticsearch.sh
-RUN /var/tmp/circleci/install_mecab.sh
-RUN /var/tmp/circleci/install_phantomjs.sh
-RUN chmod +x /usr/local/bin/phantomjs
-RUN sudo apt-get install -y libfontconfig
+RUN sudo /var/tmp/circleci/install_elasticsearch.sh
+RUN /var/tmp/elasticsearch-1.7.1/bin/plugin --install elasticsearch/elasticsearch-analysis-kuromoji/2.6.0
+RUN /var/tmp/elasticsearch-1.7.1/bin/plugin --install elasticsearch/elasticsearch-analysis-smartcn/2.7.0
 
-RUN echo "mysql-server-5.6 mysql-server/root_password password password" | sudo debconf-set-selections
-RUN echo "mysql-server-5.6 mysql-server/root_password_again password password" | sudo debconf-set-selections
-RUN sudo apt-get install -y mysql-server-5.6
-RUN sudo /bin/bash -l -c "cd /etc/mysql && patch -p0 < /var/tmp/circleci/my.cnf.diff"
+# 2.1.1
+RUN sudo /var/tmp/circleci/install_phantomjs.sh
 
-RUN sudo apt install -y libmysqlclient-dev
-RUN sudo apt install -y libcurl4-openssl-dev
-RUN sudo apt install -y mongodb
-RUN sudo apt install -y imagemagick
+RUN echo "mysql-server-5.7 mysql-server/root_password password password" | sudo debconf-set-selections
+RUN echo "mysql-server-5.7 mysql-server/root_password_again password password" | sudo debconf-set-selections
+RUN sudo apt install -y mysql-server libmysqlclient-dev
+RUN sudo /bin/bash -l -c "cd /etc/mysql/mysql.conf.d && patch -p0 < /var/tmp/circleci/mysqld.cnf.diff"
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-RUN sudo apt install -y nodejs
-
-# Install Ruby 2.2.10
+RUN sudo apt-add-repository -y ppa:rael-gc/rvm
+RUN sudo apt update
+RUN sudo apt install -y rvm
 RUN /bin/bash -l -c "rvm install 2.4.4"
 RUN /bin/bash -l -c "gem install bundler"
 RUN echo "source /etc/profile.d/rvm.sh" >> /root/.bashrc
+
+# Needed for cld gem
+ENV CFLAGS="-Wno-narrowing"
+ENV CXXFLAGS="-Wno-narrowing"
+
+RUN chmod +x /usr/local/bin/phantomjs
 
 CMD /bin/bash

--- a/circleci/install_elasticsearch.sh
+++ b/circleci/install_elasticsearch.sh
@@ -3,6 +3,7 @@ if [[ ! -e /var/tmp/elasticsearch-1.7.1 ]]; then
   cd /var/tmp
   wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz
   tar -xvf elasticsearch-1.7.1.tar.gz
-  elasticsearch-1.7.1/bin/plugin --install elasticsearch/elasticsearch-analysis-kuromoji/2.6.0
-  elasticsearch-1.7.1/bin/plugin --install elasticsearch/elasticsearch-analysis-smartcn/2.7.0
+  chmod +x elasticsearch-1.7.1/bin/plugin
+  #elasticsearch-1.7.1/bin/plugin --install elasticsearch/elasticsearch-analysis-kuromoji/2.6.0
+  #elasticsearch-1.7.1/bin/plugin --install elasticsearch/elasticsearch-analysis-smartcn/2.7.0
 fi


### PR DESCRIPTION
The base image trusty 14.04 reached end-of-life and no longer receives software updates.

Rebuild the image on bionic 18.04 LTS, which will be supported until 2020.

## TODO

- [ ] Pass a test run on kuma's CircleCI

## Pending

Most of the supplementary scripts in `circleci` become obsolete because the latest packages are now available out of the box.

- [ ] Update Elasticsearch