### PR TITLE
Add Elasticsearch 6.2 to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,19 @@ ENV CXXFLAGS="-Wno-narrowing"
 
 RUN chmod +x /usr/local/bin/phantomjs
 
+RUN /bin/bash -l -c "cd /var/tmp && wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.2.tar.gz"
+RUN /bin/bash -l -c "cd /var/tmp && tar -xvf elasticsearch-6.2.2.tar.gz"
+RUN chmod +x /var/tmp/elasticsearch-6.2.2/bin/elasticsearch-plugin
+RUN /var/tmp/elasticsearch-6.2.2/bin/elasticsearch-plugin install analysis-kuromoji
+RUN /var/tmp/elasticsearch-6.2.2/bin/elasticsearch-plugin install analysis-smartcn
+
+RUN groupadd -g 999 kuma
+RUN useradd -r -u 999 -g kuma kuma
+RUN mkhomedir_helper kuma
+RUN chmod -R 777 /var/tmp/elasticsearch-6.2.2
+RUN chmod -R 777 /var/tmp/elasticsearch-1.7.1
+USER kuma
+ENV PATH="/opt/jdk1.8.0_144/bin:${PATH}"
+RUN echo "source /etc/profile.d/rvm.sh" >> /home/kuma/.bashrc
+
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,12 @@ RUN chmod +x /var/tmp/elasticsearch-6.2.2/bin/elasticsearch-plugin
 RUN /var/tmp/elasticsearch-6.2.2/bin/elasticsearch-plugin install analysis-kuromoji
 RUN /var/tmp/elasticsearch-6.2.2/bin/elasticsearch-plugin install analysis-smartcn
 
-RUN groupadd -g 999 kuma
-RUN useradd -r -u 999 -g kuma kuma
-RUN mkhomedir_helper kuma
+RUN useradd -m kuma && echo "kuma:kuma" | chpasswd && adduser kuma sudo
 RUN chmod -R 777 /var/tmp/elasticsearch-6.2.2
 RUN chmod -R 777 /var/tmp/elasticsearch-1.7.1
+RUN mkdir -p /usr/share/rvm/rubies/ruby-2.4.4/lib/ruby/gems/2.4.0/gems/bundler-1.16.3/exe
+RUN ln -s /usr/share/rvm/rubies/ruby-2.4.4/lib/ruby/gems/2.4.0/gems/bundler-1.16.2/exe/bundle /usr/share/rvm/rubies/ruby-2.4.4/lib/ruby/gems/2.4.0/gems/bundler-1.16.3/exe/bundle
+
 USER kuma
 ENV PATH="/opt/jdk1.8.0_144/bin:${PATH}"
 RUN echo "source /etc/profile.d/rvm.sh" >> /home/kuma/.bashrc


### PR DESCRIPTION
https://hub.docker.com/r/atsui/kuma_ci/tags/
Tag: `ruby2.4.4-elasticsearch6.2`

* Ubuntu Bionic 18.04
* Ruby 2.4.4
* Elasticsearch 6.2
  * kuromoji analyzer
  * smartcn analyzer

## Notes

* Elasticsearch 6.2 cannot run as root, so set up a non-root user that has sudo privileges so they can also run necessary services like mysql
  * Default user: kuma
  * Default password: kuma
* Add a symlink for missing bundler path